### PR TITLE
Add Kafka Iceberg/ClickHouse and Terraform pipeline samples

### DIFF
--- a/Kafka/KafkaConnectClickHousePipeline/README.md
+++ b/Kafka/KafkaConnectClickHousePipeline/README.md
@@ -1,0 +1,59 @@
+# Streaming Analytics Pipeline - Terraform (Kafka + Kafka Connect + ClickHouse on AWS VPC)
+
+## Description
+A single Terraform configuration (`main_03_gist.tf`) that provisions an Instaclustr
+BYOC streaming analytics pipeline peered into your own AWS VPC.
+
+**Technologies:** Apache Kafka (primary), Kafka Connect, ClickHouse, AWS VPC, Terraform.
+
+## What it does
+Provisions and wires together, in `us-east-1`:
+- Instaclustr Kafka, Kafka Connect, and ClickHouse clusters (all `AWS_VPC`,
+  `NON_PRODUCTION` SLA tier).
+- An AWS VPC with public and private subnets, an internet gateway, and route tables.
+- Firewall rules for each cluster, scoped to the Kafka Connect VPC, your pipeline
+  VPC, and your own IP.
+- An optional EC2 test instance (Amazon Linux 2023, Kafka CLI tools pre-installed)
+  for connectivity testing - toggle with `enable_test_instance`.
+- Outputs for every cluster (IDs, private IPs, bootstrap servers, ClickHouse
+  hostnames) plus a step-by-step `vpc_peering_instructions` block covering the manual
+  peering work Terraform cannot do.
+
+## Prerequisites
+- Terraform, with the `instaclustr` (`~> 2.0`) and `aws` (`~> 5.0`) providers.
+- An Instaclustr account and an Instaclustr API (Terraform) key.
+- AWS credentials - either an SSO/named profile (`var.aws_profile`) or exported
+  credentials / environment variables.
+- Your Instaclustr BYOC provider account name (set `var.provider_account_name`).
+
+## Examples / how to run
+1. Create a `terraform.tfvars` and set at minimum:
+   - `instaclustr_terraform_key` - your Instaclustr API key
+   - `my_ip_address` - your IP in CIDR form (e.g. 203.0.113.50/32)
+   - `provider_account_name` - your Instaclustr BYOC account name
+2. Authenticate to AWS (SSO example):
+   aws sso login && export $(aws configure export-credentials --profile YOUR_PROFILE --format env)
+3. Apply:
+   terraform init
+   terraform apply
+4. Follow the `vpc_peering_instructions` output to complete the manual VPC peering
+   and Connected Clusters steps.
+
+## Additional Materials
+Tutorial: https://www.instaclustr.com/blog/how-to-build-a-streaming-analytics-pipeline-with-terraform-and-instaclustr-part-3-integrating-with-aws-vpc/
+
+## Notes
+- VPC peering is not transitive. Kafka Connect and ClickHouse need their own direct
+  peering connection in addition to the pipeline-VPC peerings.
+- The Kafka Connect target uses `kafka_connect_vpc_type = "VPC_PEERED"` (not
+  `KAFKA_VPC`) - an undocumented gotcha when peering into your own VPC.
+- Use the ClickHouse domain names (`clickhouse_domain_names` output) for TLS/SNI,
+  not the raw IPs. `clickhouse_endpoints` is an alias of the same value kept for
+  compatibility with earlier drafts.
+- The Amazon Linux 2023 AMI is hardcoded for `us-east-1` to avoid requiring
+  `ssm:GetParameter`; change it if you switch regions.
+- All sensitive values are variables (no real credentials are committed). Replace the
+  placeholder `provider_account_name` default with your own account name before applying.
+
+## License
+Apache 2.0

--- a/Kafka/KafkaConnectClickHousePipeline/main_03_gist.tf
+++ b/Kafka/KafkaConnectClickHousePipeline/main_03_gist.tf
@@ -1,0 +1,463 @@
+terraform {
+  required_providers {
+    instaclustr = {
+      source  = "instaclustr/instaclustr"
+      version = "~> 2.0"
+    }
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+# =============================================================================
+# Variables
+# =============================================================================
+
+variable "instaclustr_terraform_key" {
+  description = "Instaclustr API key"
+  type        = string
+  sensitive   = true
+}
+
+variable "my_ip_address" {
+  description = "Your IP address for firewall rules (CIDR format)"
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region (must match Instaclustr region)"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "aws_profile" {
+  description = "AWS CLI profile name after `aws configure sso` (e.g. my-company-sso). Leave null or \"\" to use the default credential chain (instance role, env vars, or `aws configure export-credentials`)."
+  type        = string
+  default     = null
+  nullable    = true
+}
+
+variable "aws_vpc_cidr" {
+  description = "CIDR block for AWS VPC"
+  type        = string
+  default     = "10.10.0.0/16"
+}
+
+variable "aws_public_subnet_cidr" {
+  description = "CIDR for public subnet"
+  type        = string
+  default     = "10.10.1.0/24"
+}
+
+variable "aws_private_subnet_cidr" {
+  description = "CIDR for private subnet"
+  type        = string
+  default     = "10.10.2.0/24"
+}
+
+variable "enable_test_instance" {
+  description = "Create EC2 test instance"
+  type        = bool
+  default     = true
+}
+
+variable "provider_account_name" {
+  description = "Instaclustr BYOC provider account name"
+  type        = string
+  default     = "<<< YOUR INSTACLUSTR ACCOUNT NAME HERE >>>"
+}
+
+# =============================================================================
+# Providers
+# =============================================================================
+
+provider "instaclustr" {
+  terraform_key = var.instaclustr_terraform_key
+}
+
+provider "aws" {
+  region = var.aws_region
+  # SSO / named profiles: set var.aws_profile. Otherwise omit (null) and use exported creds or env.
+  profile = var.aws_profile != null && var.aws_profile != "" ? var.aws_profile : null
+}
+
+# =============================================================================
+# Data Sources
+# =============================================================================
+
+data "aws_caller_identity" "current" {}
+
+# Hardcoded AMI for Amazon Linux 2023 (us-east-1)
+# Note: The SSM Parameter Store lookup requires ssm:GetParameter permission
+# which may not be available in all accounts. Use a hardcoded AMI instead.
+locals {
+  amazon_linux_2023_ami = "ami-0c02fb55956c7d316"
+  # Instaclustr exposes connection hostnames on node attributes; use for connector TLS/SNI (article: clickhouse_domain_names).
+  clickhouse_connection_hosts = [for node in instaclustr_clickhouse_cluster_v2.clickhouse.data_centre[0].nodes : node.public_address]
+}
+
+# =============================================================================
+# Kafka Cluster
+# =============================================================================
+
+resource "instaclustr_kafka_cluster_v3" "kafka" {
+  name                         = "kafka"
+  description                  = "Kafka with AWS VPC peering"
+  kafka_version                = "4.1.1"
+  sla_tier                     = "NON_PRODUCTION"
+  auto_create_topics           = true
+  allow_delete_topics          = true
+  client_to_cluster_encryption = false
+  private_network_cluster      = false
+  pci_compliance_mode          = false
+  default_number_of_partitions = 3
+  default_replication_factor   = 3
+
+  data_centre {
+    cloud_provider        = "AWS_VPC"
+    name                  = "AWS_VPC_US_EAST_1"
+    network               = "10.0.0.0/16"
+    region                = "US_EAST_1"
+    number_of_nodes       = 3
+    node_size             = "KFK-DEV-t4g.small-5"
+    provider_account_name = var.provider_account_name
+  }
+}
+
+# =============================================================================
+# ClickHouse Cluster
+# =============================================================================
+
+resource "instaclustr_clickhouse_cluster_v2" "clickhouse" {
+  name                    = "clickhouse"
+  description             = "ClickHouse with AWS VPC peering"
+  clickhouse_version      = "25.8.16"
+  sla_tier                = "NON_PRODUCTION"
+  private_network_cluster = false
+
+  data_centre {
+    cloud_provider        = "AWS_VPC"
+    name                  = "AWS_VPC_US_EAST_1"
+    network               = "10.6.0.0/16"
+    region                = "US_EAST_1"
+    node_size             = "CLK-DEV-m7i.large-50"
+    shards                = 1
+    replicas              = 3
+    provider_account_name = var.provider_account_name
+  }
+}
+
+# =============================================================================
+# Kafka Connect Cluster
+# =============================================================================
+
+resource "instaclustr_kafka_connect_cluster_v2" "connect" {
+  name                    = "connect"
+  description             = "Kafka Connect with AWS VPC peering"
+  kafka_connect_version   = "4.1.1"
+  sla_tier                = "NON_PRODUCTION"
+  private_network_cluster = false
+
+  data_centre {
+    cloud_provider        = "AWS_VPC"
+    name                  = "AWS_VPC_US_EAST_1"
+    network               = "10.2.0.0/16"
+    region                = "US_EAST_1"
+    number_of_nodes       = 3
+    node_size             = "KCN-DEV-t4g.medium-30"
+    replication_factor    = 3
+    provider_account_name = var.provider_account_name
+  }
+
+  target_cluster {
+    managed_cluster {
+      kafka_connect_vpc_type  = "VPC_PEERED"
+      target_kafka_cluster_id = instaclustr_kafka_cluster_v3.kafka.id
+    }
+  }
+}
+
+# =============================================================================
+# Firewall Rules
+# =============================================================================
+
+resource "instaclustr_cluster_network_firewall_rules_v2" "kafka_firewall" {
+  cluster_id = instaclustr_kafka_cluster_v3.kafka.id
+
+  firewall_rule {
+    network = "10.2.0.0/16" # Kafka Connect VPC
+    type    = "KAFKA"
+  }
+
+  firewall_rule {
+    network = var.aws_vpc_cidr # Your pipeline VPC
+    type    = "KAFKA"
+  }
+
+  firewall_rule {
+    network = var.my_ip_address
+    type    = "KAFKA"
+  }
+}
+
+resource "instaclustr_cluster_network_firewall_rules_v2" "clickhouse_firewall" {
+  cluster_id = instaclustr_clickhouse_cluster_v2.clickhouse.id
+
+  firewall_rule {
+    network = "10.2.0.0/16" # Kafka Connect VPC
+    type    = "CLICKHOUSE"
+  }
+
+  firewall_rule {
+    network = "10.2.0.0/16"
+    type    = "CLICKHOUSE_WEB"
+  }
+
+  firewall_rule {
+    network = var.aws_vpc_cidr
+    type    = "CLICKHOUSE"
+  }
+
+  firewall_rule {
+    network = var.aws_vpc_cidr
+    type    = "CLICKHOUSE_WEB"
+  }
+
+  firewall_rule {
+    network = var.my_ip_address
+    type    = "CLICKHOUSE"
+  }
+
+  firewall_rule {
+    network = var.my_ip_address
+    type    = "CLICKHOUSE_WEB"
+  }
+}
+
+resource "instaclustr_cluster_network_firewall_rules_v2" "connect_firewall" {
+  cluster_id = instaclustr_kafka_connect_cluster_v2.connect.id
+
+  firewall_rule {
+    network = var.aws_vpc_cidr
+    type    = "KAFKA_CONNECT"
+  }
+
+  firewall_rule {
+    network = var.my_ip_address
+    type    = "KAFKA_CONNECT"
+  }
+}
+
+# =============================================================================
+# AWS VPC Infrastructure
+# =============================================================================
+
+resource "aws_vpc" "main" {
+  cidr_block           = var.aws_vpc_cidr
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  tags = {
+    Name    = "pipeline-vpc"
+    Project = "instaclustr-tutorial"
+  }
+}
+
+resource "aws_internet_gateway" "main" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "pipeline-igw" }
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.main.id
+  cidr_block              = var.aws_public_subnet_cidr
+  availability_zone       = "us-east-1a"
+  map_public_ip_on_launch = true
+  tags                    = { Name = "pipeline-public" }
+}
+
+resource "aws_subnet" "private" {
+  vpc_id            = aws_vpc.main.id
+  cidr_block        = var.aws_private_subnet_cidr
+  availability_zone = "us-east-1a"
+  tags              = { Name = "pipeline-private" }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.main.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.main.id
+  }
+
+  tags = { Name = "pipeline-public-rt" }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.main.id
+  tags   = { Name = "pipeline-private-rt" }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "private" {
+  subnet_id      = aws_subnet.private.id
+  route_table_id = aws_route_table.private.id
+}
+
+# =============================================================================
+# Security Group & EC2 Test Instance
+# =============================================================================
+
+resource "aws_security_group" "test_instance" {
+  name        = "pipeline-test-sg"
+  description = "Security group for connectivity testing"
+  vpc_id      = aws_vpc.main.id
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = [var.my_ip_address]
+    description = "SSH access"
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["18.206.107.24/29"]
+    description = "EC2 Instance Connect for us-east-1"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = { Name = "pipeline-test-sg" }
+}
+
+resource "aws_instance" "test" {
+  count = var.enable_test_instance ? 1 : 0
+
+  ami                         = local.amazon_linux_2023_ami
+  instance_type               = "t3.micro"
+  subnet_id                   = aws_subnet.public.id
+  vpc_security_group_ids      = [aws_security_group.test_instance.id]
+  associate_public_ip_address = true
+
+  user_data = <<-EOF
+              #!/bin/bash
+              yum update -y
+              yum install -y nc telnet curl java-17-amazon-corretto
+
+              # Install Kafka CLI tools
+              cd /opt
+              curl -O https://archive.apache.org/dist/kafka/3.7.0/kafka_2.13-3.7.0.tgz
+              tar -xzf kafka_2.13-3.7.0.tgz
+              ln -s kafka_2.13-3.7.0 kafka
+              echo 'export PATH=$PATH:/opt/kafka/bin' >> /etc/profile.d/kafka.sh
+              EOF
+
+  tags = { Name = "pipeline-test" }
+}
+
+# =============================================================================
+# Outputs
+# =============================================================================
+
+output "aws_account_id"       { value = data.aws_caller_identity.current.account_id }
+output "aws_vpc_id"           { value = aws_vpc.main.id }
+output "aws_vpc_cidr"         { value = aws_vpc.main.cidr_block }
+output "aws_route_table_id"   { value = aws_route_table.public.id }
+
+output "kafka_cluster_id" { value = instaclustr_kafka_cluster_v3.kafka.id }
+output "kafka_private_ips" {
+  value = [for node in instaclustr_kafka_cluster_v3.kafka.data_centre[0].nodes : node.private_address]
+}
+output "kafka_bootstrap_servers" {
+  value = join(",", [for node in instaclustr_kafka_cluster_v3.kafka.data_centre[0].nodes : "${node.public_address}:9093"])
+}
+
+output "clickhouse_cluster_id" { value = instaclustr_clickhouse_cluster_v2.clickhouse.id }
+output "clickhouse_private_ips" {
+  value = [for node in instaclustr_clickhouse_cluster_v2.clickhouse.data_centre[0].nodes : node.private_address]
+}
+output "clickhouse_domain_names" {
+  description = "Hostnames for ClickHouse HTTPS (use with connector hostname / TLS); same source as clickhouse_endpoints."
+  value       = local.clickhouse_connection_hosts
+}
+output "clickhouse_endpoints" {
+  description = "Alias of clickhouse_domain_names for compatibility with older drafts."
+  value       = local.clickhouse_connection_hosts
+}
+
+output "kafka_connect_cluster_id" { value = instaclustr_kafka_connect_cluster_v2.connect.id }
+output "kafka_connect_private_ips" {
+  value = [for node in instaclustr_kafka_connect_cluster_v2.connect.data_centre[0].nodes : node.private_address]
+}
+
+output "test_instance_id"         { value = var.enable_test_instance ? aws_instance.test[0].id : null }
+output "test_instance_public_ip"  { value = var.enable_test_instance ? aws_instance.test[0].public_ip : null }
+
+output "vpc_peering_instructions" {
+  value = <<-EOT
+
+    ╔══════════════════════════════════════════════════════════════════════════╗
+    ║                     VPC PEERING (customer BYOC)                        ║
+    ╠══════════════════════════════════════════════════════════════════════════╣
+    ║  All cluster VPCs and your pipeline VPC are in YOUR AWS account          ║
+    ║  (${data.aws_caller_identity.current.account_id}).                        ║
+    ╠══════════════════════════════════════════════════════════════════════════╣
+    ║                                                                          ║
+    ║  STEP 1: Instaclustr Console — pipeline VPC <-> each cluster (×3)        ║
+    ║  For Kafka, Kafka Connect, and ClickHouse: cluster -> Settings ->          ║
+    ║  VPC Peering -> Add VPC Peering / New VPC Connection. Enter:              ║
+    ║    • AWS Account ID : ${data.aws_caller_identity.current.account_id}
+    ║    • VPC ID         : ${aws_vpc.main.id}
+    ║    • VPC CIDR       : ${var.aws_vpc_cidr}
+    ║    • Region         : ${var.aws_region}
+    ║                                                                          ║
+    ║  STEP 2: AWS Console - accept + route in YOUR pipeline VPC               ║
+    ║  VPC -> Peering Connections -> Accept each pending request (×3).           ║
+    ║  Route table ${aws_route_table.public.id} -> add routes:                 ║
+    ║    • 10.0.0.0/16 -> pcx-xxx (Kafka)                                       ║
+    ║    • 10.2.0.0/16 -> pcx-xxx (Kafka Connect)                               ║
+    ║    • 10.6.0.0/16 -> pcx-xxx (ClickHouse)                                  ║
+    ║                                                                          ║
+    ║  STEP 3: AWS Console — Kafka Connect VPC ↔ ClickHouse VPC (direct)       ║
+    ║  Required: VPC peering is NOT transitive; Connect (10.2.0.0/16) and      ║
+    ║  ClickHouse (10.6.0.0/16) need their own peering in THIS account.         ║
+    ║                                                                        ║
+    ║  VPC → Peering Connections → Create peering connection:                ║
+    ║    • Requester: Kafka Connect managed VPC (10.2.0.0/16)                  ║
+    ║    • Accepter:  ClickHouse managed VPC (10.6.0.0/16)                     ║
+    ║                                                                        ║
+    ║  Create -> Accept (same account).                                         ║
+    ║  Routes on BOTH sides (subnet-associated / non-main RTs as needed):      ║
+    ║    • Connect VPC RT:    10.6.0.0/16 -> that pcx-*                          ║
+    ║    • ClickHouse VPC RT: 10.2.0.0/16 -> same pcx-*                         ║
+    ║  Do not add 10.2.0.0/16 as a remote route inside the Connect VPC.        ║
+    ║                                                                          ║
+    ║  STEP 4: Instaclustr — Connected Clusters (TLS trust, not peering)      ║
+    ║  Kafka Connect cluster → Connected Clusters → add ClickHouse; leave        ║
+    ║  "Use Private IPs" unchecked per tutorial. Then sink uses                ║
+    ║  /trusted-clusters.jks and ClickHouse DOMAIN from outputs (not raw IP).    ║
+    ║                                                                          ║
+    ║  STEP 5: EC2 Instance Connect — reachability (same ports as E2E)         ║
+    ║    nc -zv <KAFKA_PRIVATE_IP> 9093                                        ║
+    ║    nc -zv <CLICKHOUSE_PRIVATE_IP> 8443                                   ║
+    ║                                                                          ║
+    ╚══════════════════════════════════════════════════════════════════════════╝
+
+  EOT
+}

--- a/Kafka/KafkaIcebergClickHouse/README.md
+++ b/Kafka/KafkaIcebergClickHouse/README.md
@@ -1,0 +1,50 @@
+# Kafka -> Iceberg -> ClickHouse
+
+## Description
+Sample scripts and minimal IAM policies for streaming events from Kafka into an
+Apache Iceberg table on S3 (cataloged in AWS Glue), so the data can be queried
+downstream with ClickHouse.
+
+**Technologies:** Apache Kafka (primary), Apache Iceberg, AWS Glue, Amazon S3, ClickHouse.
+
+## What it does
+- `create_iceberg_table.py` - creates the `analytics.user_events` Iceberg table on
+  S3 via PyIceberg + AWS Glue, partitioned by day, and seeds it with 500 sample rows.
+- `produce_events_aio.py` - produces synthetic user events to a Kafka topic using
+  aiokafka (SASL/SCRAM).
+- `command-config.props` - Kafka CLI credentials file for `kafka-topics.sh` /
+  `kafka-acls.sh`.
+- `glue-minimal-policy.json` / `s3-minimal-policy.json` - least-privilege IAM
+  policies for the Glue and S3 access the pipeline needs.
+
+## Prerequisites
+- Apache Kafka cluster (e.g. Instaclustr managed Apache Kafka) with SASL/SCRAM credentials.
+- Python 3.11+ (the producer uses `datetime.UTC`).
+- `pip install "pyiceberg[glue,pyiceberg-core]" pyarrow boto3 aiokafka`
+- An AWS account with an S3 bucket and permission to create Glue databases/tables.
+- Kafka CLI tools (for use with `command-config.props`).
+
+## Examples / how to run
+1. Fill in placeholders: Kafka credentials in `command-config.props`, `S3_BUCKET`
+   and `AWS_REGION` in `create_iceberg_table.py`, and the `KAFKA_*` env vars below.
+2. Attach the IAM policies (`glue-minimal-policy.json`, `s3-minimal-policy.json`) to
+   the role or user running the scripts.
+3. Create the Iceberg table:
+   python create_iceberg_table.py
+4. Produce events to Kafka:
+   export KAFKA_BOOTSTRAP="<broker1>:9092,<broker2>:9092"
+   export KAFKA_USER="<your-kafka-username>"
+   export KAFKA_PASSWORD="<your-kafka-password>"
+   python produce_events_aio.py
+
+## Additional Materials
+<!-- TODO: add link to the related blog post / YouTube video / talk -->
+
+## Notes
+- All credentials are placeholders - replace them before running, and never commit
+  real secrets.
+- The IAM policies are intentionally minimal; widen the actions/resources only if
+  your setup requires it.
+
+## License
+Apache 2.0

--- a/Kafka/KafkaIcebergClickHouse/README.md
+++ b/Kafka/KafkaIcebergClickHouse/README.md
@@ -38,7 +38,7 @@ downstream with ClickHouse.
    python produce_events_aio.py
 
 ## Additional Materials
-<!-- TODO: add link to the related blog post / YouTube video / talk -->
+Blog: [Kafka to Iceberg: Build a queryable data lake with ClickHouse](https://www.instaclustr.com/blog/kafka-to-iceberg-build-a-queryable-data-lake-with-clickhouse/)
 
 ## Notes
 - All credentials are placeholders - replace them before running, and never commit

--- a/Kafka/KafkaIcebergClickHouse/command-config.props
+++ b/Kafka/KafkaIcebergClickHouse/command-config.props
@@ -1,0 +1,10 @@
+# command-config.props
+# Kafka CLI credentials file for kafka-topics.sh and kafka-acls.sh commands.
+# Used when creating the control topic and setting ACLs.
+#
+# Replace the placeholders with your actual Kafka credentials from
+# Instaclustr: Kafka cluster -> Connection Info -> Default Credentials
+
+security.protocol=SASL_PLAINTEXT
+sasl.mechanism=SCRAM-SHA-256
+sasl.jaas.config=org.apache.kafka.common.security.scram.ScramLoginModule required username="<your-kafka-username>" password="<your-kafka-password>";

--- a/Kafka/KafkaIcebergClickHouse/create_iceberg_table.py
+++ b/Kafka/KafkaIcebergClickHouse/create_iceberg_table.py
@@ -1,0 +1,60 @@
+# create_iceberg_table.py
+# Creates an Iceberg table on S3 using PyIceberg with AWS Glue as the catalog.
+# Run this once before deploying the Kafka Connect Iceberg Sink Connector.
+#
+# Requirements:
+#   pip install "pyiceberg[glue,pyiceberg-core]" pyarrow boto3
+#
+# AWS credentials must have permission to:
+#   - Write to your S3 bucket
+#   - Create Glue databases and tables
+
+from pyiceberg.catalog.glue import GlueCatalog
+from pyiceberg.schema import Schema
+from pyiceberg.types import NestedField, StringType, TimestampType, LongType
+from pyiceberg.partitioning import PartitionSpec, PartitionField
+from pyiceberg.transforms import DayTransform
+import pyarrow as pa
+from datetime import datetime, timedelta
+import random
+
+S3_BUCKET = "<your-bucket-name>"
+AWS_REGION = "<your-aws-region>"
+WAREHOUSE_PATH = f"s3://{S3_BUCKET}/warehouse"
+
+catalog = GlueCatalog("glue", **{
+    "region_name": AWS_REGION,
+    "warehouse": WAREHOUSE_PATH,
+})
+
+catalog.create_namespace_if_not_exists("analytics")
+
+schema = Schema(
+    NestedField(1, "event_id", LongType(), required=False),
+    NestedField(2, "user_id", StringType(), required=False),
+    NestedField(3, "event_type", StringType(), required=False),
+    NestedField(4, "page", StringType(), required=False),
+    NestedField(5, "event_ts", TimestampType(), required=False),
+)
+
+partition_spec = PartitionSpec(
+    PartitionField(source_id=5, field_id=1000, transform=DayTransform(), name="event_day")
+)
+
+table = catalog.create_table_if_not_exists(
+    identifier="analytics.user_events",
+    schema=schema,
+    partition_spec=partition_spec,
+)
+
+event_types = ["page_view", "click", "signup", "purchase", "logout"]
+pages = ["/home", "/pricing", "/docs", "/blog", "/signup", "/checkout"]
+base_time = datetime(2025, 2, 10, 8, 0, 0)
+
+records = [{"event_id": i+1, "user_id": f"u_{random.randint(1000,1099)}",
+            "event_type": random.choice(event_types), "page": random.choice(pages),
+            "event_ts": base_time + timedelta(minutes=random.randint(0, 2880))}
+           for i in range(500)]
+
+table.append(pa.Table.from_pylist(records))
+print(f"Wrote {len(records)} records to {WAREHOUSE_PATH}")

--- a/Kafka/KafkaIcebergClickHouse/glue-minimal-policy.json
+++ b/Kafka/KafkaIcebergClickHouse/glue-minimal-policy.json
@@ -1,0 +1,18 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "GlueAccess",
+      "Effect": "Allow",
+      "Action": [
+        "glue:GetTable",
+        "glue:GetDatabase"
+      ],
+      "Resource": [
+        "arn:aws:glue:<your-aws-region>:<your-aws-account-id>:catalog",
+        "arn:aws:glue:<your-aws-region>:<your-aws-account-id>:database/analytics",
+        "arn:aws:glue:<your-aws-region>:<your-aws-account-id>:table/analytics/*"
+      ]
+    }
+  ]
+}

--- a/Kafka/KafkaIcebergClickHouse/produce_events_aio.py
+++ b/Kafka/KafkaIcebergClickHouse/produce_events_aio.py
@@ -1,0 +1,45 @@
+# produce_events_aio.py
+# Produces synthetic user events to a Kafka topic using aiokafka.
+#
+# Requirements:
+#   pip install aiokafka
+#
+# Set environment variables before running:
+#   export KAFKA_BOOTSTRAP="<broker1>:9092,<broker2>:9092"
+#   export KAFKA_USER="<your-kafka-username>"
+#   export KAFKA_PASSWORD="<your-kafka-password>"
+
+import asyncio, json, os, random
+from aiokafka import AIOKafkaProducer
+from datetime import datetime, UTC
+
+KAFKA_BOOTSTRAP = os.environ.get("KAFKA_BOOTSTRAP", "<your-kafka-bootstrap>:9092")
+KAFKA_USER      = os.environ.get("KAFKA_USER", "<your-kafka-username>")
+KAFKA_PASSWORD  = os.environ.get("KAFKA_PASSWORD", "<your-kafka-password>")
+KAFKA_TOPIC     = os.environ.get("KAFKA_TOPIC", "user-events")
+
+event_types = ["page_view", "click", "signup", "purchase", "logout"]
+pages = ["/home", "/pricing", "/docs", "/blog", "/signup", "/checkout"]
+
+async def produce():
+    producer = AIOKafkaProducer(
+        bootstrap_servers=KAFKA_BOOTSTRAP,
+        security_protocol="SASL_PLAINTEXT",
+        sasl_mechanism="SCRAM-SHA-256",
+        sasl_plain_username=KAFKA_USER,
+        sasl_plain_password=KAFKA_PASSWORD,
+        value_serializer=lambda v: json.dumps(v).encode(),
+    )
+    await producer.start()
+    try:
+        for i in range(50):
+            event = {"event_id": i+1, "user_id": f"u_{random.randint(1000,1099)}",
+                     "event_type": random.choice(event_types), "page": random.choice(pages),
+                     "event_ts": datetime.now(UTC).isoformat()}
+            await producer.send(KAFKA_TOPIC, key=event["user_id"].encode(), value=event)
+        await producer.flush()
+        print(f"Produced 50 events to '{KAFKA_TOPIC}'")
+    finally:
+        await producer.stop()
+
+asyncio.run(produce())

--- a/Kafka/KafkaIcebergClickHouse/s3-minimal-policy.json
+++ b/Kafka/KafkaIcebergClickHouse/s3-minimal-policy.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "S3Access",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListBucket",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::<your-bucket-name>",
+        "arn:aws:s3:::<your-bucket-name>/*"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds two Kafka-primary samples under Kafka/: a Kafka -> Iceberg -> ClickHouse pipeline (scripts + minimal IAM policies) and a Terraform streaming-analytics pipeline (Kafka + Connect + ClickHouse on AWS VPC). All credentials are placeholders; internal naming sanitized.